### PR TITLE
[AV-82442] Update Kotlin release 1.1 docs for Free Tier

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -131,7 +131,7 @@ Here's an example that shows how to execute a {sqlpp} (formerly N1QL) query and 
 Couchbase Capella::
 +
 --
-This version of the example assumes you are connecting to a https://docs.couchbase.com/cloud/index.html[Couchbase Capella] perpetual free tier operational cluster, which has the `travel-sample` bucket installed by default.
+This version of the example assumes you are connecting to a https://docs.couchbase.com/cloud/index.html[Couchbase Capella] free tier operational cluster, which has the `travel-sample` bucket installed by default.
 
 (If you're not using Couchbase Capella, click the **Local Couchbase Server** tab above.)
 

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -131,7 +131,7 @@ Here's an example that shows how to execute a {sqlpp} (formerly N1QL) query and 
 Couchbase Capella::
 +
 --
-This version of the example assumes you are connecting to a https://docs.couchbase.com/cloud/index.html[Couchbase Capella] trial cluster, which has the `travel-sample` bucket installed by default.
+This version of the example assumes you are connecting to a https://docs.couchbase.com/cloud/index.html[Couchbase Capella] perpetual free tier operational cluster, which has the `travel-sample` bucket installed by default.
 
 (If you're not using Couchbase Capella, click the **Local Couchbase Server** tab above.)
 


### PR DESCRIPTION
Removed mentions of trial in the Kotlin SDK docs. Only locations found were the start-using-sdk.adoc page.