### PR TITLE
Remove JVMCBC-1628 from release notes

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -32,12 +32,6 @@ https://docs.couchbase.com/sdk-api/couchbase-kotlin-client-1.5.0/index.html[API 
 | http://docs.couchbase.com/sdk-api/couchbase-core-io-3.8.0/[Core API Reference]
 
 
-==== Bugfixes
-
-* https://couchbasecloud.atlassian.net/browse/JVMCBC-1628[JVMCBC-1628]:
-Specifying `DISABLE_READ_SKEW_DETECTION` was causing transactional `getMulti` to fail.
-This has now been fixed.
-
 ==== New Features
 
 * https://jira.issues.couchbase.com/browse/KCBC-190[KCBC-190]:


### PR DESCRIPTION
JVMCBC-1628 is for a bug introduced in the same version, so doesn't need to be included in release notes.