### PR TITLE
Release notes for 3.11.1

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -7,7 +7,7 @@ nav:
 asciidoc:
   attributes:
     server_version: '8.0.0'
-    sdk_current_version: '3.11.0'
+    sdk_current_version: '3.11.1'
     sdk_dot_minor: 3.11
     sdk_dot_major: 3.x
     version-server: '8.0'

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -29,6 +29,24 @@ any changes to expected behavior are noted in the release notes that follow.
 // TODO - add missing colons after JIRA links to bring consistency.
 
 
+[[v3.11.1]]
+=== Version 3.11.1 (16 February 2026)
+
+https://docs.couchbase.com/sdk-api/couchbase-kotlin-client-3.11.1/index.html[API Reference] |
+https://docs.couchbase.com/sdk-api/couchbase-core-io-3.11.1/[Core API Reference]
+
+This critical release fixes a regression in `3.11.0` that caused documents inserted in transactions to expire immediately.
+
+==== Bug Fixes
+
+* https://jira.issues.couchbase.com/browse/JVMCBC-1712[JVMCBC-1712]:
+Document inserted in transactions no longer expire immediately.
+This fixes a regression in `3.11.0`.
+
+==== Improvements
+
+* https://jira.issues.couchbase.com/browse/KCBC-198[KCBC-198]:
+Exposed the `observabilitySemanticConventions` client setting.
 
 
 [[v3.11.0]]
@@ -38,8 +56,8 @@ https://docs.couchbase.com/sdk-api/couchbase-kotlin-client-3.11.0/index.html[API
 https://docs.couchbase.com/sdk-api/couchbase-core-io-3.11.0/[Core API Reference]
 
 [CAUTION]
-This version has a serious bug that causes a document inserted in a transaction to expire immediately.
-If your project uses transactions, we recommend staying on 3.10.1 until 3.11.1 is available.
+This version has https://jira.issues.couchbase.com/browse/JVMCBC-1712[a serious bug that causes documents inserted in transactions to expire immediately].
+We recommend upgrading directly to `3.11.1`.
 
 Kotlin 2.1 is now the minimum required version.
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>kotlin-client</artifactId>
-            <version>3.11.0</version>
+            <version>3.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
A note about the anchor tag:

I used `[[v3.11.1]]` to override the default anchor name here for consistency with the previous few Kotlin versions. (I did _not_ do this for Java and Scala).

You can see the result in the existing Kotlin release notes: https://docs.couchbase.com/kotlin-sdk/current/project-docs/sdk-release-notes.html

Notice how the heading in the right sidebar is the full "version x.y.x (date)", but if you click 3.11.0 in the right sidebar the fragment in the address bar is just `#v3.11.0`. Contrast with the `#version-3-9-2-10-october-2025` you get if you click on the 3.9.2 release in the right sidebar.