### PR TITLE
Release notes for 3.11.2

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -27,7 +27,7 @@ We recommend running the latest Java LTS version with the highest patch version 
 
 == Installing the SDK
 
-All stable versions of the SDK are https://central.sonatype.com/artifact/com.couchbase.client/kotlin-client/{kotlin-current-version}[available on Maven Central].
+All stable versions of the SDK are https://central.sonatype.com/artifact/com.couchbase.client/kotlin-client[available on Maven Central].
 
 You can use your favorite dependency management tool to include the SDK in your project.
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -29,6 +29,23 @@ any changes to expected behavior are noted in the release notes that follow.
 // TODO - add missing colons after JIRA links to bring consistency.
 
 
+[[v3.11.2]]
+=== Version 3.11.2 (13 April 2026)
+
+https://docs.couchbase.com/sdk-api/couchbase-kotlin-client-3.11.2/index.html[API Reference] |
+https://docs.couchbase.com/sdk-api/couchbase-core-io-3.11.2/[Core API Reference]
+
+This maintenance release upgrades Netty and Jackson to the latest versions.
+
+==== Improvements
+
+* https://jira.issues.couchbase.com/browse/JVMCBC-1726[JVMCBC-1726]:
+Upgraded Netty from to `4.2.9` to `4.2.12`.
+
+* https://jira.issues.couchbase.com/browse/JVMCBC-1723[JVMCBC-1723]:
+Upgraded Jackson from `2.20.1` to `2.21.2`.
+
+
 [[v3.11.1]]
 === Version 3.11.1 (16 February 2026)
 

--- a/modules/project-docs/partials/attributes.adoc
+++ b/modules/project-docs/partials/attributes.adoc
@@ -1,5 +1,5 @@
 :kotlin-api-link: https://docs.couchbase.com/sdk-api/couchbase-kotlin-client/
-:kotlin-current-version: 1.4.9
+:kotlin-current-version: 3.11.2
 :moshi-version: 1.13.0
 :version-server: 7.6
 :name-sdk: Kotlin SDK

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>kotlin-client</artifactId>
-            <version>3.11.1</version>
+            <version>3.11.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Also removed `{kotlin-current-version}` from the Maven Central URL because the un-versioned URL leads to a page that automatically displays the latest version.